### PR TITLE
🔀 :: JwtPlugin 테스트케이스 추가

### DIFF
--- a/Projects/Services/APIKit/Sources/Plugin/JwtPlugin.swift
+++ b/Projects/Services/APIKit/Sources/Plugin/JwtPlugin.swift
@@ -17,9 +17,7 @@ public struct JwtPlugin: PluginType {
               jwtTokenType != .none
         else { return request }
         var req = request
-        let token = jwtTokenType == .accessToken ?
-            "Bearer \(getToken(type: .accessToken))" :
-            getToken(type: .refreshToken)
+        let token = "Bearer \(getToken(type: jwtTokenType == .accessToken ? .accessToken : .refreshToken))"
 
         req.addValue(token, forHTTPHeaderField: jwtTokenType.rawValue)
         return req

--- a/Projects/Services/APIKit/Tests/JwtPluginTests.swift
+++ b/Projects/Services/APIKit/Tests/JwtPluginTests.swift
@@ -57,15 +57,33 @@ final class JwtPluginTests: QuickSpec {
                 beforeEach {
                     keychain.save(type: .accessToken, value: "Access")
                 }
-                it("header의 Authorization에 앞에 Bearer와 함께 'Access'가 자동으로 담긴다") {
+                it("HTTPHeader의 Authorization에 앞에 Bearer와 함께 'Access'가 자동으로 담긴다") {
                     api.request(.withAccess) { result in
                         switch result {
                         case .failure:
                             fail("요청이 실패..함..?")
 
                         case let .success(res):
-                            expect(res.request?.allHTTPHeaderFields?["Authorization"]).notTo(beNil())
+                            expect(res.request?.allHTTPHeaderFields?["Authorization"]).toNot(beNil())
                             expect(res.request?.allHTTPHeaderFields?["Authorization"]).to(equal("Bearer Access"))
+                            expect(res.statusCode).to(equal(200))
+                        }
+                    }
+                }
+            }
+            context("Enpoint에 Refresh를 포함해서 보낸다면") {
+                beforeEach {
+                    keychain.save(type: .refreshToken, value: "Refresh")
+                }
+                it("HTTPHeader의 Refresh-Token에 앞에 Bearer와 함께 'Refresh'가 자동으로 담긴다") {
+                    api.request(.withRefresh) { result in
+                        switch result {
+                        case .failure:
+                            fail("요청이.. 실..패..함..?")
+
+                        case let .success(res):
+                            expect(res.request?.allHTTPHeaderFields?["Refresh-Token"]).toNot(beNil())
+                            expect(res.request?.allHTTPHeaderFields?["Refresh-Token"]).to(equal("Bearer Refresh"))
                             expect(res.statusCode).to(equal(200))
                         }
                     }

--- a/Projects/Services/APIKit/Tests/JwtPluginTests.swift
+++ b/Projects/Services/APIKit/Tests/JwtPluginTests.swift
@@ -79,7 +79,7 @@ final class JwtPluginTests: QuickSpec {
                     api.request(.withRefresh) { result in
                         switch result {
                         case .failure:
-                            fail("요청이.. 실..패..함..?")
+                            fail("요청이 실패함 (비정상적인 상황)")
 
                         case let .success(res):
                             expect(res.request?.allHTTPHeaderFields?["Refresh-Token"]).toNot(beNil())

--- a/Projects/Services/APIKit/Tests/JwtPluginTests.swift
+++ b/Projects/Services/APIKit/Tests/JwtPluginTests.swift
@@ -61,7 +61,7 @@ final class JwtPluginTests: QuickSpec {
                     api.request(.withAccess) { result in
                         switch result {
                         case .failure:
-                            fail("요청이 실패..함..?")
+                            fail("요청이 실패함 (비정상적인 상황)")
 
                         case let .success(res):
                             expect(res.request?.allHTTPHeaderFields?["Authorization"]).toNot(beNil())


### PR DESCRIPTION
## 💡 개요
Endpoint의 JwtTokenType이 RefreshToken일때 자동으로 Refresh-Token 필드에 키체인 안에 있는 RefreshToken이 담기는지 테스트 케이스

## 📃 작업내용
JwtPlugin에 테스트케이스 추가
